### PR TITLE
Plane and Vehicle Script changes

### DIFF
--- a/Assets/Scripts/Plane.cs
+++ b/Assets/Scripts/Plane.cs
@@ -1,15 +1,18 @@
 using UnityEngine;
-using UnityEngine.InputSystem;
 using Vehicles;
 
 public class Plane : Vehicle
 {
+    [SerializeField] private float rollSpeed;
+    [SerializeField] private float pitchSpeed;
+    [SerializeField] private float yawSpeed;
+
     [SerializeField] private GameObject[] propellers;
     [SerializeField] private GameObject[] wheels;
 
-    [SerializeField] private float thrust = 0;
+    private float thrust = 0;
 
-    [SerializeField] private float trueThrust = 0;
+    private float trueThrust = 0;
 
     private Vector2 moveAmt;
     private float thrustAmt;
@@ -58,15 +61,15 @@ public class Plane : Vehicle
         {
             liftOff = true;
             rigidbody.useGravity = false;
-            transform.Rotate(Vector3.right, 30f * Time.fixedDeltaTime * moveAmt.y);
+            transform.Rotate(Vector3.right, pitchSpeed * Time.fixedDeltaTime * moveAmt.y);
 
-            transform.Rotate(Vector3.forward, 10f * Time.fixedDeltaTime * -moveAmt.x);
+            transform.Rotate(Vector3.forward, rollSpeed * Time.fixedDeltaTime * -moveAmt.x);
         }
         else
         {
             liftOff = false;
             rigidbody.useGravity = true;
-            transform.Rotate(Vector3.up, 2.5f * Time.fixedDeltaTime * moveAmt.x);
+            transform.Rotate(Vector3.up, yawSpeed * Time.fixedDeltaTime * moveAmt.x);
         }
 
 

--- a/Assets/Scripts/Vehicle.cs
+++ b/Assets/Scripts/Vehicle.cs
@@ -14,6 +14,9 @@ namespace Vehicles
 
         protected Vector3 prevPosition;
 
+        protected Vector3 spawnPosition;
+        protected Quaternion spawnRotation;
+
         [SerializeField] protected VehicleData vehicleData;
 
         protected new Rigidbody rigidbody;
@@ -21,6 +24,9 @@ namespace Vehicles
         // Start is called once before the first frame Update
         protected virtual void Awake()
         {
+            spawnPosition = transform.position;
+            spawnRotation = transform.rotation;
+
             rigidbody = GetComponent<Rigidbody>();
             rigidbody.mass = vehicleData.mass;
             rigidbody.maxLinearVelocity = vehicleData.maxSpeed;
@@ -49,5 +55,16 @@ namespace Vehicles
 
         public abstract void EnableInput();
         public abstract void DisableInput();
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (other.gameObject.CompareTag("Killzone"))
+            {
+                transform.position = spawnPosition;
+                transform.rotation = spawnRotation;
+                rigidbody.linearVelocity = Vector3.zero;
+                rigidbody.angularVelocity = Vector3.zero;
+            }
+        }
     }
 }


### PR DESCRIPTION
Vehicle Script:
- made it so that when it triggered the killzone it would go back to the spawn location with it's linear and angular velocities set to 0

Plane Script:
- removed the thrust variables from the editor
- added roll, pitch, and yaw speed variables changeable from the editor
- removed "using UnityEngine.InputSystem;". Even though the plane uses the InputSystem apparently the "using" statement was not required